### PR TITLE
Gulp 4

### DIFF
--- a/Gulpfile.coffee
+++ b/Gulpfile.coffee
@@ -128,9 +128,9 @@ gulp.task 'mochify:cover', (done) ->
 	.on 'end', -> done()
 	.bundle()
 
-gulp.task 'build', ['build:html', 'build:js', 'build:css']
-gulp.task 'release', ['build:html:release', 'build:js:release', 'build:css:release']
-gulp.task 'serve', ['connect', 'watch']
-gulp.task 'test', ['mochify:node', 'mochify:phantom']
+gulp.task 'build', gulp.parallel 'build:html', 'build:js', 'build:css'
+gulp.task 'release', gulp.parallel 'build:html:release', 'build:js:release', 'build:css:release'
+gulp.task 'serve', gulp.parallel 'connect', 'watch'
+gulp.task 'test', gulp.parallel 'mochify:node', 'mochify:phantom'
 
-gulp.task 'default', ['test']
+gulp.task 'default', gulp.task 'test'

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "coffeeify": "~2.0.1",
     "core-js": "~2.4.0",
     "coveralls": "~2.11.4",
-    "gulp": "~3.9.0",
+    "gulp": "gulpjs/gulp#4.0",
     "gulp-clean-css": "~2.0.3",
     "gulp-connect": "~4.0.0",
     "gulp-jade": "~1.1.0",


### PR DESCRIPTION
This is mainly to remove deprecation warnings from `npm install` and Gulp runtime error messages.